### PR TITLE
Step 5: Sidebar and controls

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,15 +1,32 @@
-import { useState } from 'react'
+import useRouteGenerator from './hooks/useRouteGenerator'
 import MapView from './components/MapView'
+import Sidebar from './components/Sidebar'
 
 function App() {
-  const [startPoint, setStartPoint] = useState(null)
+  const {
+    startPoint, setStartPoint,
+    distance, setDistance,
+    routeData, loading, error,
+    generateRoute, downloadGPX, regenerate,
+  } = useRouteGenerator()
 
   return (
-    <div id="app">
+    <div id="app" className="app-layout">
       <MapView
         startPoint={startPoint}
         onStartPointSet={setStartPoint}
-        routeCoordinates={null}
+        routeCoordinates={routeData?.coordinates ?? null}
+      />
+      <Sidebar
+        startPoint={startPoint}
+        distance={distance}
+        setDistance={setDistance}
+        routeData={routeData}
+        loading={loading}
+        error={error}
+        generateRoute={generateRoute}
+        downloadGPX={downloadGPX}
+        regenerate={regenerate}
       />
     </div>
   )

--- a/frontend/src/components/DistanceInput.jsx
+++ b/frontend/src/components/DistanceInput.jsx
@@ -1,0 +1,66 @@
+const CHIPS = [
+  { label: '3k', value: 3 },
+  { label: '5k', value: 5 },
+  { label: '10k', value: 10 },
+  { label: '15k', value: 15 },
+  { label: 'Half', value: 21.1 },
+]
+
+export default function DistanceInput({ distance, setDistance, disabled }) {
+  function handleSlider(e) {
+    setDistance(parseFloat(e.target.value))
+  }
+
+  function handleNumber(e) {
+    const val = parseFloat(e.target.value)
+    if (!isNaN(val)) setDistance(val)
+  }
+
+  function handleNumberBlur(e) {
+    const val = parseFloat(e.target.value)
+    if (isNaN(val) || val < 1) setDistance(1)
+    else if (val > 50) setDistance(50)
+  }
+
+  return (
+    <div className="distance-input">
+      <label className="distance-label">Distance</label>
+      <input
+        type="range"
+        className="distance-slider"
+        min={1}
+        max={50}
+        step={0.5}
+        value={distance}
+        onChange={handleSlider}
+        disabled={disabled}
+      />
+      <div className="distance-number-row">
+        <input
+          type="number"
+          className="distance-number"
+          min={1}
+          max={50}
+          step={0.5}
+          value={distance}
+          onChange={handleNumber}
+          onBlur={handleNumberBlur}
+          disabled={disabled}
+        />
+        <span className="distance-unit">km</span>
+      </div>
+      <div className="distance-chips">
+        {CHIPS.map((chip) => (
+          <button
+            key={chip.value}
+            className={`chip${distance === chip.value ? ' chip-active' : ''}`}
+            onClick={() => setDistance(chip.value)}
+            disabled={disabled}
+          >
+            {chip.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/RouteStats.jsx
+++ b/frontend/src/components/RouteStats.jsx
@@ -1,0 +1,31 @@
+function formatTime(totalMinutes) {
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = Math.floor(totalMinutes % 60)
+  const seconds = Math.round((totalMinutes % 1) * 60)
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+  }
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}
+
+export default function RouteStats({ distance, duration }) {
+  const estMinutes = distance * 6  // ~6:00/km pace
+  const formattedTime = formatTime(estMinutes)
+
+  return (
+    <div className="route-stats">
+      <div className="stat-row">
+        <span className="stat-label">Distance</span>
+        <span className="stat-value">{distance.toFixed(1)} km</span>
+      </div>
+      <div className="stat-row">
+        <span className="stat-label">Est. time</span>
+        <span className="stat-value">{formattedTime}</span>
+      </div>
+      <div className="stat-row">
+        <span className="stat-label">Pace</span>
+        <span className="stat-value">~6:00 /km</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,38 @@
+import DistanceInput from './DistanceInput'
+import RouteStats from './RouteStats'
+
+export default function Sidebar({
+  startPoint, distance, setDistance,
+  routeData, loading, error,
+  generateRoute, downloadGPX, regenerate,
+}) {
+  return (
+    <aside className="sidebar">
+      <h1 className="sidebar-title">rundrop</h1>
+      <DistanceInput distance={distance} setDistance={setDistance} disabled={loading} />
+      <button
+        className="btn btn-primary"
+        onClick={generateRoute}
+        disabled={!startPoint || loading}
+      >
+        {loading && <span className="spinner" />}
+        {loading ? 'Generating...' : 'Generate Route'}
+      </button>
+      {error && <p className="error-message">{error}</p>}
+      {routeData && (
+        <RouteStats distance={routeData.distance} duration={routeData.duration} />
+      )}
+      {routeData && (
+        <div className="sidebar-actions">
+          <button className="btn btn-secondary" onClick={downloadGPX}>
+            Download GPX
+          </button>
+          <button className="btn btn-secondary" onClick={regenerate}>
+            Regenerate
+          </button>
+        </div>
+      )}
+      {!startPoint && <p className="hint">Click the map to set a start point</p>}
+    </aside>
+  )
+}

--- a/frontend/src/hooks/useRouteGenerator.js
+++ b/frontend/src/hooks/useRouteGenerator.js
@@ -1,0 +1,67 @@
+import { useState, useEffect } from 'react'
+
+export default function useRouteGenerator() {
+  const [startPoint, setStartPoint] = useState(null)     // { lat, lng } | null
+  const [distance, setDistance] = useState(5)              // km (number)
+  const [routeData, setRouteData] = useState(null)         // { coordinates, distance, duration } | null
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)                 // string | null
+
+  // Reset route when start point changes
+  useEffect(() => {
+    setRouteData(null)
+    setError(null)
+  }, [startPoint])
+
+  async function generateRoute() {
+    if (!startPoint) return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/generate?lat=${startPoint.lat}&lng=${startPoint.lng}&distance=${distance}`)
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to generate route')
+      }
+      const data = await res.json()
+      setRouteData(data)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function downloadGPX() {
+    if (!routeData) return
+    try {
+      const res = await fetch('/api/export-gpx-from-coords', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ coordinates: routeData.coordinates }),
+      })
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'rundrop-route.gpx'
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      setError('Failed to download GPX file')
+    }
+  }
+
+  function regenerate() {
+    generateRoute()
+  }
+
+  return {
+    startPoint, setStartPoint,
+    distance, setDistance,
+    routeData, loading, error,
+    generateRoute, downloadGPX, regenerate,
+  }
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -46,3 +46,219 @@
 .location-button:hover {
   background: #f4f4f4;
 }
+
+/* Layout */
+.app-layout {
+  display: flex;
+  height: 100vh;
+}
+
+.map-container {
+  flex: 1;
+}
+
+/* Sidebar */
+.sidebar {
+  width: 340px;
+  padding: 24px;
+  background: #fafafa;
+  border-left: 1px solid #e0e0e0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  flex-shrink: 0;
+}
+
+.sidebar-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-accent);
+  margin: 0;
+}
+
+/* Distance Input */
+.distance-input {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.distance-label {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: #333;
+}
+
+.distance-slider {
+  width: 100%;
+  accent-color: var(--color-accent);
+}
+
+.distance-number-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.distance-number {
+  width: 80px;
+  padding: 6px 8px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.distance-unit {
+  color: #666;
+  font-size: 0.875rem;
+}
+
+.distance-chips {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  padding: 6px 14px;
+  border-radius: 16px;
+  border: 1px solid #ccc;
+  background: white;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  transition: all 0.15s ease;
+}
+
+.chip:hover:not(:disabled) {
+  border-color: var(--color-accent);
+}
+
+.chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chip-active {
+  background: var(--color-accent);
+  color: white;
+  border-color: var(--color-accent);
+}
+
+/* Buttons */
+.btn {
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  font-size: 0.875rem;
+  transition: opacity 0.15s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-primary {
+  background: var(--color-accent);
+  color: white;
+  width: 100%;
+}
+
+.btn-primary:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: white;
+  color: #333;
+  border: 1px solid #ccc;
+  flex: 1;
+}
+
+.btn-secondary:hover {
+  background: #f5f5f5;
+}
+
+.sidebar-actions {
+  display: flex;
+  gap: 10px;
+}
+
+/* Route Stats */
+.route-stats {
+  background: white;
+  border-radius: 8px;
+  padding: 16px;
+  border: 1px solid #e0e0e0;
+}
+
+.stat-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+}
+
+.stat-label {
+  color: #666;
+  font-size: 0.875rem;
+}
+
+.stat-value {
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+/* Loading Spinner */
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid white;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  margin-right: 8px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Error & Hint */
+.error-message {
+  color: #d32f2f;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.hint {
+  color: #999;
+  font-size: 0.875rem;
+  font-style: italic;
+  margin: 0;
+}
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+  .app-layout {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    height: auto;
+    max-height: 40vh;
+    border-left: none;
+    border-top: 1px solid #e0e0e0;
+  }
+
+  .map-container {
+    height: 60vh;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the sidebar UI with all controls for the rundrop route generator:

- **DistanceInput**: Synced slider (1–50km), number input, and quick-pick chips (3k, 5k, 10k, 15k, Half Marathon)
- **RouteStats**: Displays route distance and estimated time at ~6:00/km pace
- **Sidebar**: Container with Generate Route button (loading spinner), Download GPX, and Regenerate
- **useRouteGenerator hook**: State management + API integration for route generation and GPX export
- **App.jsx refactored** to two-column flex layout (map + sidebar) with mobile responsive breakpoint at 768px

## Files changed

| File | Action |
|------|--------|
| `frontend/src/hooks/useRouteGenerator.js` | Created — state + API calls |
| `frontend/src/components/DistanceInput.jsx` | Created — slider, number, chips |
| `frontend/src/components/RouteStats.jsx` | Created — distance + time display |
| `frontend/src/components/Sidebar.jsx` | Created — controls container |
| `frontend/src/App.jsx` | Modified — two-column layout |
| `frontend/src/styles/app.css` | Modified — +216 lines of styles |

## Test plan

- [ ] Click map → orange marker appears, Generate button becomes enabled
- [ ] Move slider → number input and chip highlight update
- [ ] Type in number input → slider moves, matching chip highlights
- [ ] Click quick-pick chip (e.g. "10k") → slider and input update to 10
- [ ] Click Generate → button shows spinner + "Generating...", inputs disabled
- [ ] After generation → route polyline on map, stats show distance + time
- [ ] Click Download GPX → browser downloads `rundrop-route.gpx`
- [ ] Click Regenerate → new route generated with same start/distance
- [ ] Set start point in ocean → error message appears in red
- [ ] Resize below 768px → sidebar stacks below map

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)